### PR TITLE
changed statement with globals() to locals()

### DIFF
--- a/Scripts/Gene/__init__.py
+++ b/Scripts/Gene/__init__.py
@@ -51,7 +51,7 @@ class Gene:
 
 		os.system ('ls ' + self.PathtoOutput + '/fasta2keep/' + self.OG + '* > ' + self.PathtoOutput + '/' + self.OG + '_list')
 		seqsList = open(self.PathtoOutput + '/' + self.OG + '_list', 'r').readlines()
-		if "seqsList" in globals(): 
+		if "seqsList" in locals(): 
 			os.system('cat ' + self.PathtoOutput + '/' + self.OG + '_filtered.fas' + ' ' +  self.PathtoOutput + '/fasta2keep/' + self.OG + '* > ' + self.PathtoOutput + '/' + self.OG + '_all.fas')
 		else:
 			os.system('cp '+ self.PathtoOutput + '/' + self.OG + '_filtered.fas ' + self.PathtoOutput + '/' + self.OG + '_all.fas')


### PR DESCRIPTION
The statements searches for a variable that contains the information of a file. This variable is defined inside a method. So, it should be in locals() and not in globals(). Because of this error sequences from fasta2keep were not combined with sequences from orthomcl. So, we were getting pre and post guidance files with only orthomcl taxa. For some reason, I think this is the cause of an error just before second iteration of contamination loop. I corrected the statement it corrected all errors.