### PR TITLE
changes for performing contamination removal in the GFs DB

### DIFF
--- a/Scripts/Gene/__init__.py
+++ b/Scripts/Gene/__init__.py
@@ -51,9 +51,16 @@ class Gene:
 
 		os.system ('ls ' + self.PathtoOutput + '/fasta2keep/' + self.OG + '* > ' + self.PathtoOutput + '/' + self.OG + '_list')
 		seqsList = open(self.PathtoOutput + '/' + self.OG + '_list', 'r').readlines()
-		if "seqsList" in locals(): 
+		
+		gf_and_at = "n"
+		if "seqsList" in locals():
+			if not seqsList == []:
+				gf_and_at = "y"
+		
+		if gf_and_at == "y":
 			os.system('cat ' + self.PathtoOutput + '/' + self.OG + '_filtered.fas' + ' ' +  self.PathtoOutput + '/fasta2keep/' + self.OG + '* > ' + self.PathtoOutput + '/' + self.OG + '_all.fas')
 		else:
+			print("You are working only with the gene families database, not added taxa database. If this is intentional ignore the last error message")
 			os.system('cp '+ self.PathtoOutput + '/' + self.OG + '_filtered.fas ' + self.PathtoOutput + '/' + self.OG + '_all.fas')
 
 ##############################################################################

--- a/Scripts/Utilities.py
+++ b/Scripts/Utilities.py
@@ -48,8 +48,8 @@ def iterGuidance(oglist, og, PathtoOutput, guidanceIter, seqcutoff, colcutoff, r
 				
 		if str(mode) != "ng":
 			print("\n" + og + ": Running Guidance")
-			print('bash exeGuidance_2.2.sh -i ' + path2og + ' -o ' + tempdir + ' -t 1 -c ' + outdir + ' -g ' + str(guidanceIter) + ' -s ' + str(seqcutoff) + ' -l ' + str(colcutoff) + ' -r ' + str(rescutoff) + ' -m ' + str(mode))
-			os.system('bash exeGuidance_2.2.sh -i ' + path2og + ' -o ' + tempdir + ' -t 1 -c ' + outdir + ' -g ' + str(guidanceIter) + ' -s ' + str(seqcutoff) + ' -l ' + str(colcutoff) + ' -r ' + str(rescutoff) + ' -m ' + str(mode))
+			print('bash exeGuidance_2.2.sh -i ' + path2og + ' -o ' + tempdir + ' -t 20 -c ' + outdir + ' -g ' + str(guidanceIter) + ' -s ' + str(seqcutoff) + ' -l ' + str(colcutoff) + ' -r ' + str(rescutoff) + ' -m ' + str(mode))
+			os.system('bash exeGuidance_2.2.sh -i ' + path2og + ' -o ' + tempdir + ' -t 20 -c ' + outdir + ' -g ' + str(guidanceIter) + ' -s ' + str(seqcutoff) + ' -l ' + str(colcutoff) + ' -r ' + str(rescutoff) + ' -m ' + str(mode))
 			os.system('cp ' + path2og + ' ' + tokeepdir + og + '_preguidance.fas') # non-aligned pre-guidance file		
 		
 #			if not os.path.exists(outdir + og + 'forGuidance.fas.output/NInitialSeqBelow4') or not os.path.exists(outdir + og + 'forGuidance.fas.output/NAboveCutoffBelow4'):	
@@ -161,17 +161,21 @@ from the script PhyloTOL.py
 def cleaner(testPipelineList, PathtoFiles, PathtoOutput):
 	
 	os.system('rm -f *log*')
-	os.system('rm -f *RAxML_*')	
+	os.system('rm -f *RAxML_*')
+	os.system('rm -f Utilities.pyc')
+	os.system('rm -f Gene/__init__.pyc')
+	os.system('rm -f Taxon/__init__.pyc')
+	os.system('rm -f Pipeline/__init__.pyc')
+	os.system('rm -rf __pycache__')
+	os.system('rm -rf Gene/__pycache__')
+	os.system('rm -rf Taxon/__pycache__')
+	os.system('rm -rf Pipeline/__pycache__')
+	
 	if os.path.exists(PathtoOutput + '/' + testPipelineList + '_results2keep/'):
 		os.system('mv ' + PathtoOutput + '/' + testPipelineList + '_results2keep/ ' + '../')
-	else:
-		print("error: there is a folder " + '../' + testPipelineList + '_results2keep/')
-		print("exiting the cleaner...\n")
-		quit()
+
 	os.system('rm -r ' + "../my-data/")
 	os.system('rm -r ' + PathtoFiles + 'FileLists_' + testPipelineList + '/')
-	
-	print("\n\nFind your files in folder: " + '../' + testPipelineList + '_results2keep \n\n')
 
 """
 The function contaminationRemoval removes contamination from sequence data (ncbiFiles). It is called 
@@ -185,7 +189,7 @@ file can be used for cleanning permanent databases. This file is re-written in e
 concatenates the file of every run in the file seqs2remove_all
 """
 
-def contaminationRemoval(treeFolder, PathtoFiles, rules, homologDB):
+def contaminationRemoval(treeFolder, PathtoFiles, rules, homologDB, mode):
 			
 	nonHomol_out = open("nonHomologs", "w")
 	nonHomol_treeWnhom = open("nonHomol_treeWnhom", "w")
@@ -193,7 +197,7 @@ def contaminationRemoval(treeFolder, PathtoFiles, rules, homologDB):
 	for file in os.listdir(treeFolder):
 		nonHomINtree = 'n'
 		if file.endswith('postguidance.fas_renamed.fas'):
-			og = file.split("_")[0] + "_" + file.split("_")[1]
+			og = file.replace("_postguidance.fas_renamed.fas", "")
 			postseqs = open(treeFolder + file, "r").readlines()
 			preseqs = open(treeFolder + og + '_preguidance.fas_renamed.fas', "r").readlines()
 			for preseq in preseqs:
@@ -214,6 +218,6 @@ def contaminationRemoval(treeFolder, PathtoFiles, rules, homologDB):
 	os.system('python3 walk_tree_contamination_single.py ' + treeFolder + ' sisterReport')
 	print("\nUtilities.py - contaminationRemoval(): Writing sister report ...\n")
 	time.sleep(60)
-	os.system('ruby seqs2remove.rb ' + PathtoFiles + ' sisterReport ' + rules + ' seqs2remove_out ' + 'nonHomologs')
+	os.system('ruby seqs2remove.rb ' + PathtoFiles + ' sisterReport ' + rules + ' seqs2remove_out ' + 'nonHomologs ' + mode)
 	print("\nUtilities.py - contaminationRemoval(): Replacing fasta files ...\n")
 	time.sleep(60)

--- a/Scripts/phylotol-concleaner.py
+++ b/Scripts/phylotol-concleaner.py
@@ -1,7 +1,17 @@
 import os, sys
 import Utilities
 
-script, rules = sys.argv
+script, rules, mode = sys.argv
+
+"""
+running as ...
+python phylotol-concleaner.py path_to_rules mode
+
+modes:
+c1 = cleaning contamination in gene families DB
+c2 = cleaning contamination in added taxa DB
+c3 = cleaning contamination in gene families DB and added taxa DB
+"""
 
 print("\n\n ** runing PhyloTOL-conCleaner **\n\n")
 
@@ -38,6 +48,14 @@ taxaDBfile = open(PathtoFiles + 'taxaDBpipeline3', 'r').readlines()
 taxaDB = [taxon.strip('\n') for taxon in taxaDBfile]
 homologDB = [taxon[7:] for taxon in taxaDB if taxon.split(',')[0] == 'om']
 
+# making sure that a valid mode was chosen... Valid modes are c1, c2 or c3
+
+if mode not in ["c1", "c2", "c3"]:
+	print("prease choose a correct mode of cleaning contamination:\nc1: in gene families DB\nc2: in added taxa DB\nc3: in both")
+	quit()
+else:
+	print("mode of contamination cleaning: %s\n" % mode)
+
 # Start looping ... The loop will only stop when restart changes to 'n'
 while restart == 'y': 
 	
@@ -48,7 +66,7 @@ while restart == 'y':
 		
 		# Run contamination removal. Check contaminationRemoval() in Utilities for details.  
 		print("run " + str(run) + " PhyloTOL-conCleaner: removing contamination and non-homologs ...\n")
-		Utilities.contaminationRemoval(treeFolder, PathtoFiles, rules, homologDB)
+		Utilities.contaminationRemoval(treeFolder, PathtoFiles, rules, homologDB, mode)
 		print("run " + str(run) + " PhyloTOL-conCleaner: contamination and non-homologs removal done ...")
 
 		# Inside the Temp folder create an exclusive folder for temporal files in current run and move temporary files
@@ -98,7 +116,7 @@ while restart == 'y':
 			# Run PhyloTOL
 			run += 1
 			print("run " + str(run) + " PhyloTOL-conCleaner: runing PhyloTOL with contamination removal\n\n")
-			os.system("python phylotol.py ct")  # run the pipeline with mode 'ct'
+			os.system("python phylotol.py " + mode)  # run the pipeline with mode 'ct'
 			print("run " + str(run) + " PhyloTOL-conCleaner: PhyloTOL done")
 	
 	else:
@@ -107,7 +125,7 @@ while restart == 'y':
 		
 		run += 1
 		print("run " + str(run) + " PhyloTOL-conCleaner: runing PhyloTOL - pre-contamination removal \n\n")
-		os.system("python phylotol.py ct")
+		os.system("python phylotol.py " + mode)
 		print("run " + str(run) + " PhyloTOL-conCleaner: PhyloTOL done")
 
 seqs2remove_all.close()

--- a/Scripts/phylotol.py
+++ b/Scripts/phylotol.py
@@ -59,18 +59,26 @@ def writelog(PathtoOutput,string):
 	
 def main():
 	arg = sys.argv
-	ct = 'n'
+	ct = 'c0'
+	clean = "n"
 	if len(arg) == 2:
 		mode = sys.argv[1]
 		allowed_modes = ['ng', 'nr']
-		if mode == 'ct' : ct = 'y'
+		if str(mode) == 'cl' : clean = 'y'
+		if mode in ["c1", "c2", "c3"] : ct = mode
 		if mode not in allowed_modes : mode = 'df'
 	else:
 		mode = 'df'
-	print("\n** mode -> %s **" % mode)
 		
 	PathtoFiles,testPipelineList,listTaxaInterest,blastCutOff,seqLenCompCutOff,tooSimCutOff,guidanceIter,seqcutoff,colcutoff,rescutoff,concatAlignment = get_parameters()
 	paramList = [blastCutOff,seqLenCompCutOff,tooSimCutOff,guidanceIter,seqcutoff,colcutoff,rescutoff,concatAlignment]
+
+	if clean == "y": 
+		Utilities.cleaner(testPipelineList, PathtoFiles, PathtoOutput)
+		print("cleaning folders -- done!")
+		quit()
+
+	print("\n** mode -> %s **" % mode)
 
 	print('################################################################################')
 	print('')
@@ -92,11 +100,11 @@ def main():
 	print('Guidance residue cutoff = %s' % rescutoff)
 	print('Alignment for concatenation = %s' % concatAlignment)
 	print('################################################################################')
-		
+
 	if concatAlignment is not 'y' and concatAlignment is not 'n':
 		print("\n*** your answer concatAlignment = " + concatAlignment + " is not correct. The pipeline takes 'n' as default ***")
 	
-	if not ct == 'y':
+	if ct == 'c0':
 		if os.path.exists('../' + testPipelineList + '_results2keep'):
 			print('terminating PhyloTOL: the folder ' + '../' + testPipelineList + '_results2keep exists. Choose another name for your OG list\n\n')
 			quit()
@@ -293,7 +301,7 @@ def main():
 	count = 0
 	li = []
 	for line in infile:
-		if 'OG5_' in line:
+		if 'OG' in line:
 			outfile = open(PathtoFiles+ '/FileLists_' + testPipelineList + '/list' + str(count),'w')
 			li.append('list' + str(count))
 			outfile.write(line)
@@ -305,21 +313,9 @@ def main():
 		for f in os.listdir(PathtoFiles+ '/FileLists_' + testPipelineList):			
 			newPipe = Pipeline(PathtoFiles +'/'+ testPipelineList, PathtoFiles, ('geneStep',f),paramList,taxa2analyze,taxa2SF,wholegenomeDB,mode)	
 		
-		answer_Cleaner = ''
-		valid_answers = ['y', 'n']
-
-		if ct == 'y':
-			answer_Cleaner = 'y'
-		else:
-			while (answer_Cleaner not in valid_answers):  
-				answer_Cleaner = input("\n\nDo you want to execute the cleaner? (y/n): ")
-	
-				if (answer_Cleaner not in valid_answers): 
-					print("\n\nplease answer y or n")
-	
-		if answer_Cleaner is 'y':
-			Utilities.cleaner(testPipelineList, PathtoFiles, PathtoOutput)
-		
+		### By inactivating the next line you can have access to all intermediary files
+		Utilities.cleaner(testPipelineList, PathtoFiles, PathtoOutput)
+				
 	except Exception as e:
 		elog = open('errorlog','a')
 		line = open(PathtoFiles+ '/FileLists_' + testPipelineList + '/' + f,'r').read()

--- a/Scripts/seqs2remove.rb
+++ b/Scripts/seqs2remove.rb
@@ -10,21 +10,48 @@
 # Running:
 # - Put all the imput files and folders in the same folder and run scrip with ruby: "ruby seqs2remove.rb"
 
-# ruby seqs2remove.rb path2Files sisterReport rules seqs2remove_out nonHomologs
-# ruby seqs2remove.rb ./ sisterReport rules seqs2remove_out nonHomologs
+# ruby seqs2remove.rb path2Files sisterReport rules seqs2remove_out nonHomologs mode
+# ruby seqs2remove.rb ./ sisterReport rules seqs2remove_out nonHomologs c1
 
 path = ARGV[0]
 report_summary = File.open(ARGV[1], 'r').readlines()
 rules = File.open(ARGV[2], 'r').readlines()
 sequences_contamination = File.open(ARGV[3], 'w')
 trees_contamination = File.open(ARGV[3] + '_treesWcont', 'w')
-ncbiFiles = path + '/ncbiFiles/'
-system "mkdir " + path + "/newncbi/"
-newncbi = path + '/newncbi/'
 seqs2remove = Array.new
 nonhomologs = File.open(ARGV[4], 'r').readlines()
 total2remove = nonhomologs
+mode = ARGV[5]
 
+if ["c1", "c3"].include? mode
+	ogsDir = path + '/allOG5Files/'
+	system "mkdir " + path + "/newOGdir/"
+	newOGdir = path + '/newOGdir/'
+end
+
+if ["c2", "c3"].include? mode
+	ncbiFiles = path + '/ncbiFiles/'
+	system "mkdir " + path + "/newncbi/"
+	newncbi = path + '/newncbi/'
+end
+
+# ---- correcting .fasta format ----
+def correctFasta(rawFasta)	
+	fastaseqs = Array.new
+	seq = ''
+	
+	rawFasta.each do |line|
+		if line =~ /^>/
+			if seq != '' then fastaseqs << seq end	
+			fastaseqs << line.gsub("\n", "")
+			seq = ''
+		end
+		if line =~ /^([A-z]|\*)/ then seq = seq + line.gsub("\n", "") end
+	end
+	fastaseqs << seq	
+	return fastaseqs		
+end
+#------------------------------------
 
 count = 0
 treesWcontamination = Array.new
@@ -58,68 +85,97 @@ report_summary.each do |line|
 end
 
 trees2reprocess = treesWcontamination.uniq
+(total2remove << seqs2remove).flatten!
+
 if treesWcontamination != []
 	trees2reprocess.each do |tree|
 		puts "seqs2remove.rb: tree with contamination --> " + tree
 		trees_contamination.write(tree + "\n")
 	end
-end
-
-(total2remove << seqs2remove).flatten!
-
-puts "\nseqs2remove.rb: removing sequences from Databases:"
-(Dir.open(ncbiFiles)).each do |ncbiFile|
-	if ncbiFile.include? ".fasta"
-		taxon = ncbiFile[0..9]
-		to_remove = Array.new
-		
-		ncbisequences_raw = File.open(ncbiFiles + ncbiFile, "r").readlines()
-		
-		# ---- correcting .fasta format ----
-		
-		ncbisequences = Array.new
-		seq = ''
-		ncbisequences_raw.each do |line|
-			if line =~ /^>/
-				if seq != '' then ncbisequences << seq end	
-				ncbisequences << line.gsub("\n", "")
-				seq = ''
-			end
-			if line =~ /^([A-z]|\*)/ then seq = seq + line.gsub("\n", "") end
-		end
-		ncbisequences << seq
-		
-		#------------------------------------
-		
-		newncbiTags = Array.new
-		newncbiFile = File.open(newncbi + ncbiFile, "w")
-
-		puts ncbiFile
 	
-#		seqs2remove.each do |seq2remove|
-		total2remove.each do |seq2remove|
-			seq2remove = seq2remove.gsub(/\n/, "")
-			if seq2remove.include? taxon
+	if ["c1", "c3"].include? mode
+		puts "\nseqs2remove.rb: removing sequences from Databases (OGs DB):"
+		trees2reprocess.each do |og|
+			ogSeqs_raw = File.open(ogsDir + og, "r").readlines()
+			ogSeqs = correctFasta(ogSeqs_raw)
+			newOGfile = File.open(newOGdir + og, "w")
+			to_remove = Array.new
+			total2remove.each do |seq2remove|
+				seq2remove = seq2remove.gsub(/\n/, "")
 				to_remove << seq2remove
 			end
+		
+			puts og
+
+			index = 0
+			ogSeqs.each do |ogSeq|
+				if ogSeq =~ /^>/
+					tag = ogSeq.gsub(/>|\n/, "")
+					unless to_remove.include? tag
+						newOGfile.write(ogSeq + "\n" + ogSeqs[index + 1] + "\n")
+					else
+						puts "\nremoved: " + ogSeq
+						puts "removed: " + ogSeqs[index + 1] + "\n"
+					end
+				end
+				index += 1
+			end
+			newOGfile.close
 		end
 		
-		index = 0
-		ncbisequences.each do |ncbisequence|
-			if ncbisequence =~ /^>/
-				tag = ncbisequence.gsub(/>|\n/, "")
-				unless to_remove.include? tag
-					newncbiFile.write(ncbisequence + "\n" + ncbisequences[index + 1] + "\n")
-				else
-					puts "\nremoved: " + ncbisequence
-					puts "removed: " + ncbisequences[index + 1] + "\n"
+		(Dir.open(ogsDir)).each do |og|
+			if og.include? "OG"
+				if not trees2reprocess.include? og
+					system "cp " + ogsDir + og + " " +  newOGdir
 				end
 			end
-			index += 1
 		end
-		newncbiFile.close
+		
+		system "rm -r " + ogsDir
+		system "mv " + newOGdir + " " + ogsDir
+		
 	end
 end
 
-system "rm -r " + ncbiFiles
-system "mv " + newncbi + "\t" + ncbiFiles
+if ["c2", "c3"].include? mode
+	puts "\nseqs2remove.rb: removing sequences from Databases (added taxa DB):"
+
+	(Dir.open(ncbiFiles)).each do |ncbiFile|
+		if ncbiFile.include? ".fasta"
+			taxon = ncbiFile[0..9]
+			to_remove = Array.new
+		
+			ncbisequences_raw = File.open(ncbiFiles + ncbiFile, "r").readlines()
+			ncbisequences = correctFasta(ncbisequences_raw)
+			newncbiFile = File.open(newncbi + ncbiFile, "w")
+
+			puts ncbiFile
+	
+	#		seqs2remove.each do |seq2remove|
+			total2remove.each do |seq2remove|
+				seq2remove = seq2remove.gsub(/\n/, "")
+				if seq2remove.include? taxon
+					to_remove << seq2remove
+				end
+			end
+		
+			index = 0
+			ncbisequences.each do |ncbisequence|
+				if ncbisequence =~ /^>/
+					tag = ncbisequence.gsub(/>|\n/, "")
+					unless to_remove.include? tag
+						newncbiFile.write(ncbisequence + "\n" + ncbisequences[index + 1] + "\n")
+					else
+						puts "\nremoved: " + ncbisequence
+						puts "removed: " + ncbisequences[index + 1] + "\n"
+					end
+				end
+				index += 1
+			end
+			newncbiFile.close
+		end
+	end
+
+	system "rm -r " + ncbiFiles
+	system "mv " + newncbi + " " + ncbiFiles
+end


### PR DESCRIPTION
These are changes across all scripts. These changes are intended to create 3 modes of contamination removal.

c1 = contamination removal in GFs DB (totally new). We always said that GFs DB should be already curated and didn't need contamination removal. Now, we are running PhyloToL in a de-novo GFs DB created by Ying and Xyrus and need to perform the contamination removal.

c2 = contamination removal in the added taxa DB (As previous versions of PhyloToL)

c3 = In both DBs (New).

Other change was the removal of the prompt at the end that asks if the user wants to perform folders cleaning. Now it's done by default. If the users want the intermediary files, they can just comment the line indicated in the script phylotol.py